### PR TITLE
This change introduces support for the **cri-o** container runtime ac…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -315,6 +315,36 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
+
+  deploy_image_builder_buildkitd:
+    needs: [semantic_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: needs.semantic_release.outputs.new_release_published == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: image-builder-buildkit
+          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          BUILD_CTX: utility-containers/image-builder-buildkit
+        run: |
+          cp .dockerignore $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
       - name: Cleanup Docker's Leftovers
         if: always()
         continue-on-error: true

--- a/adrs/crio/README.md
+++ b/adrs/crio/README.md
@@ -1,0 +1,92 @@
+# ADR-001: Add CRI-O Runtime Support in Orchest
+
+## Status
+
+Accepted
+
+## Context
+
+Orchest is a data platform built to run on Kubernetes, enabling data scientists and developers to define, run, and manage workflows in containerized environments. A core feature of Orchest is its **Environments** system, which allows users to define custom runtime environments. These environments are built as Docker images using BuildKit and later used during pipeline execution.
+
+Historically, Orchest supported environments on clusters using `docker` and `containerd` runtimes. However, compatibility issues were identified when trying to run Orchest on clusters using the `cri-o` runtime—commonly found in enterprise Kubernetes platforms such as Oracle Kubernetes Engine.
+
+To ensure Orchest can be deployed across all major Kubernetes runtimes, we implemented full support for `cri-o`. This involved key changes in the controller, API, build infrastructure, and runtime agents.
+
+---
+
+**Validation of CRI-O Support**:
+
+* `orchest-controller/pkg/controller/orchestcluster/cluster_utils.go` updated to detect `cri-o` by inspecting the `containerRuntimeVersion` field on Kubernetes nodes. This field is accessed via the Kubernetes API using `node.Status.NodeInfo.ContainerRuntimeVersion`, which usually contains values like `containerd://1.6.4`, `docker://20.10.8`, or `cri-o://1.23.0`. Orchest parses this string by splitting on the `://` delimiter to extract the runtime name (`containerd`, `docker`, or `cri-o`). This extracted runtime name determines the appropriate default socket path for communication with the container runtime and informs logic across the system to adjust behavior for that runtime.
+* `orchest-controller/pkg/controller/orchestcluster/cluster_controller.go` updated to allow `buildkit-daemon` deployment when the runtime is CRI-O.
+
+2. **BuildKit Daemonset for CRI-O**:
+
+   * New function `getBuildKitDaemonCrioDaemonset` in `buildkit_daemon.go` generates a CRI-O specific DaemonSet using `oci-worker`. This worker mode is required because CRI-O is not compatible with containerd workers. The function ensures the correct container runtime socket (`/var/run/crio/crio.sock`) and the container storage path (`/var/lib/containers/storage`) are mounted. These mounts are essential for both BuildKit operations and for enabling the `node-agent` (running in a different pod) to access the images built within the CRI-O build pod. This setup also ensures readiness and liveness probes for the buildkitd service work consistently across runtimes.
+
+3. **Manifests Adaptation**:
+
+   * `orchest-api/app/core/image_utils.py` extended with CRI-O-specific logic to correctly configure volume mounts and manifest content for image building. This included defining dedicated mounts for the BuildKit socket and CRI-O's storage directory (`/var/lib/containers/storage`). These updates ensure that when the image is built and loaded via `podman` (as required by CRI-O), the resulting image remains accessible to the `node-agent` on a separate pod. Moreover, manifest generation logic was adapted to include necessary `--opt` flags and argument formatting specific to CRI-O's OCI worker mode, maintaining compatibility across container runtimes.
+
+4. **Image Output Handling**:
+
+   * Unlike `containerd`, CRI-O does not support containerd workers within BuildKit. To maintain compatibility and avoid significant changes in `node-agent`, the chosen strategy was to use BuildKit's `--output type=docker,...` option to save the built image as a tarball.
+   * This tarball is then loaded using `podman`, a tool that works well with CRI-O storage layers.
+   * Using the `push=true` option (which pushes the image directly to a registry) would have required architectural changes to the `node-agent`, which currently checks image availability and manages lifecycle within the registry.
+   * Keeping image lifecycle responsibility with `node-agent` ensures consistent logic across runtimes and avoids potential race conditions.
+   * To support CRI-O, we needed a tool that could load Docker-formatted images into the container storage used by CRI-O. `podman` was chosen due to its compatibility with the CRI-O runtime. However, using podman introduced two challenges:
+
+     * Older versions had a bug affecting the image naming when loading tarballs ([podman#12560](https://github.com/containers/podman/issues/12560)).
+     * Newer versions (above 4.9.0) crash with segmentation faults when `/var/lib/containers/storage` is mounted into the pod. However, mounting this volume was necessary because the images loaded with podman need to be accessible by the node-agent, which runs in a separate pod and relies on accessing this shared storage path.
+   * To resolve both issues, we updated the Alpine package source to access newer packages and explicitly pinned `podman` to version 4.5.1, the latest stable version that avoids both limitations.
+
+5. **Runtime Abstraction**:
+
+   * `node-agent/app/container_runtime.py` updated to use `crictl` when `RuntimeType.Crio` is detected.
+
+6. **Environment Variable Overrides**:
+
+   * `orchest-api/app/config.py` updated to support runtime-specific image builder configuration by reading the environment variables `DOCKER_IMAGE_BUILDER_IMAGE`, `CONTAINERD_IMAGE_BUILDER_IMAGE`, and `CRIO_IMAGE_BUILDER_IMAGE`. If these are unset, the system falls back to the default values pointing to `docker.io/orchest/...`. This approach allows users to override the image builder container used for each runtime independently, providing flexibility for enterprise environments or air-gapped deployments, without requiring significant structural changes to propagate such overrides from the OrchestCluster specification to downstream components like `orchest-api` or `celery-worker`.
+
+## Consequences
+
+* **Pros**:
+
+  * Orchest now supports clusters running CRI-O.
+  * User-customizable image builder pipelines.
+  * Transparent runtime abstraction across Docker, containerd, and CRI-O.
+
+* **Cons**:
+
+  * Increased complexity in the deployment and environment configuration.
+  * More runtime-specific code and logic scattered across services.
+
+## Communication Flow for CRI-O Image Build
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant orchest-api
+    participant celery-worker
+    participant buildkitd Pod (CRI-O)
+    participant podman
+    participant node-agent
+
+    User->>orchest-api: Request to build environment image
+    orchest-api->>celery-worker: Queue image build task
+    celery-worker->>buildkitd Pod (CRI-O): Launch image build with buildctl
+    buildkitd Pod (CRI-O)->>podman: Save image to tarball and load it
+    podman->>node-agent: Store image under /var/lib/containers/storage
+    node-agent-->>orchest-api: Image available on node
+```
+
+## Related Commits / PRs
+
+See [diff.txt](./diff.txt) for the detailed changes made across the services.
+
+## Authors
+
+* Engineering Team at Dadosfera
+
+## Date
+
+2025-05-07

--- a/adrs/crio/prompt.md
+++ b/adrs/crio/prompt.md
@@ -1,0 +1,24 @@
+We have an software that has the following components:
+orchest-controller (responsible for creating components in K8s, it creates the core components like orchest-api, orchest-webserver, rabbitmq, postgresql, celery-worker, buildkit-daemon, node-agent) -> 
+
+orchest-api is the main API -> use celery-worker for background tasks
+
+In orchest, we have an feature called Environments where the use can place custom code and generate an docker image. This images are generated in a pod with the buildkitd and buildctl.
+
+The issue is that this worked with containerd and docker, but not with cri-o. Which is currently used by oracle.
+
+We have faced some issues:
+1. orchest-controller does not validate orchest clusters that uses cri-o. So this has to be changed. so we have to make this possible.
+2. For using cri-o, we would also need orchest-controller to deploy buildkit-daemon service for cri-o, not just for containerd as it was today.
+3. Had to update the manifesto for buildkitdaemon to have a specialization for cri-o.
+4. Had to update orchest-api and orchest-worker to create the manifests of the image-build-task correctly for cri-o.
+5. when using containerd runtime, our builkit daemon use containerd workers, but they're not compatible with cri-o. So, we have to change to oci workers in this cases. However, ocis worker does not store images, they just ignore the store=true parameter. In this way, we had two options, to save the image as tarball and load it to the node using some other tool or use push=true and push it directly to the registry. While the second one sounds more intuitive, this would involve architectural changes in the node-agent because currently, the node-agent checks if an image is in the registry or not, and if not, it push to the registry. IT also checks if an image is not required anymore and delete from the registry. That's why we went with the first approach. 
+6. Using the first approach had its issues as well:
+  a. First, we would need to generate a tarball. This was possible using --output type=docker,name=...,dest=/tmp/output.tar. However, while trying to load it to the registry using podman, we found the following issue: https://github.com/containers/podman/issues/12560. So, decided to identify a version where this bug was corrected.
+  b. The podman in the current alpine version is too low, so had to update the alpine pkg to newer versions. 
+  c. However, this doesn't solve one problem that is: the image built by buildctl should be available for the node-agent. Solved this by mounting the folder /var/lib/containers/storage inside the image-build-task pod.
+  d. But, this generates a conflict with podman newer version > 4.9.0. Had to downgrade podman to version 4.5.1.
+  e. After downgrading podman, I was able to build the image, store it on /var/lib/containers/storage and access the new built image from node-agent.
+7. Some adaptations in the image-build-task to use crictl for image pull when teh CONTAINER_RUNTIME_SOCKET is cri-o.
+8. We have to give the possibility for the user to customize the image that will be used to build images for all runtimes (containerd, docker and crio). There will be a default image (pointing to docker.io/orchest). But, the users will be able to use the envvars DOCKER_IMAGE_BUILDER_IMAGE, CONTAINERD_IMAGE_BUILDER_IMAGE and CRIO_IMAGE_BUILDER_IMAGE. This approach was taken because propagating the env variable from the OrchestCluster -> OrchestComponent -> Orchest API deployment would involve significant changes because we would have to change the OrchestComponent definition. Today is possible to customized images for the core components, but not for components that are created by the API and Celery workers.
+9. Made some adaptations on the node-agent to be compatible with crio by using crictl when the ENV Variable CONTAINER_RUNTIME_SOCKET=cri-o

--- a/services/orchest-api/app/app/apis/namespace_ctl.py
+++ b/services/orchest-api/app/app/apis/namespace_ctl.py
@@ -125,10 +125,11 @@ class OrchestImagesToPrePull(Resource):
             _config.CONTAINER_RUNTIME_IMAGE,
             f"docker.io/orchest/base-kernel-py:{CONFIG_CLASS.ORCHEST_VERSION}",
             f"docker.io/orchest/jupyter-enterprise-gateway:{CONFIG_CLASS.ORCHEST_VERSION}",  # noqa
-            f"docker.io/orchest/session-sidecar:{CONFIG_CLASS.ORCHEST_VERSION}",
+            f"docker.io/orchest/session-sidecar:{CONFIG_CLASS.ORCHEST_VERSION}"
         ]
 
         pre_pull_orchest_images.append(self._get_jupyter_image_name())
+        pre_pull_orchest_images = {"pre_pull_images": pre_pull_orchest_images}
 
         return pre_pull_orchest_images, 200
 

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -32,8 +32,8 @@ class Config:
     # Whether Orchest is running on single-node. This in turn determines
     # how pipeline runs are executed; in 1 pod or 1 pod per step.
     SINGLE_NODE = os.environ.get("SINGLE_NODE") == "TRUE"
-    ORCHEST_VERSION = os.environ["ORCHEST_VERSION"].split('-')[0]
-    ORCHEST_DADOSFERA_VERSION = os.environ['ORCHEST_VERSION']
+    ORCHEST_VERSION = os.environ["ORCHEST_VERSION"].split("-")[0]
+    ORCHEST_DADOSFERA_VERSION = os.environ["ORCHEST_VERSION"]
     # must be uppercase
     SQLALCHEMY_DATABASE_URI = "postgresql://postgres@orchest-database/orchest_api"
 
@@ -63,8 +63,18 @@ class Config:
 
     # Image building.
     _RUNTIME_TO_IMAGE_BUILDER = {
-        "docker": f"docker.io/orchest/image-builder-buildx:{ORCHEST_VERSION}",
-        "containerd": f"docker.io/orchest/image-builder-buildkit:{ORCHEST_VERSION}",
+        "docker": os.environ.get(
+            "DOCKER_IMAGE_BUILDER_IMAGE",
+            f"docker.io/orchest/image-builder-buildx:{ORCHEST_VERSION}",
+        ),
+        "containerd": os.environ.get(
+            "CONTAINERD_IMAGE_BUILDER_IMAGE",
+            f"docker.io/orchest/image-builder-buildkit:{ORCHEST_VERSION}",
+        ),
+        "cri-o": os.environ.get(
+            "CRIO_IMAGE_BUILDER_IMAGE",
+            f"docker.io/orchest/image-builder-buildkit:{ORCHEST_VERSION}",
+        ),
     }
     IMAGE_BUILDER_IMAGE = _RUNTIME_TO_IMAGE_BUILDER[_config.CONTAINER_RUNTIME]
 

--- a/services/orchest-controller/deploy/thirdparty/docker-registry/orchest-values.yaml
+++ b/services/orchest-controller/deploy/thirdparty/docker-registry/orchest-values.yaml
@@ -8,7 +8,7 @@ serviceAccount:
 fullnameOverride: docker-registry
 
 image:
-  repository: registry
+  repository: docker.io/registry
   tag: 2.7.1
   pullPolicy: IfNotPresent
 

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -907,7 +907,7 @@ func (occ *OrchestClusterController) manageOrchestCluster(ctx context.Context, o
 		// Do not create the buildkit-daemon when not needed.
 		if componentName == controller.BuildKitDaemon {
 			containerRuntime, _, _ := detectContainerRuntime(ctx, occ.Client(), orchest)
-			if containerRuntime != "containerd" {
+			if containerRuntime != "containerd" && containerRuntime != "cri-o" {
 				continue
 			}
 		}

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
@@ -535,13 +535,15 @@ func detectContainerRuntime(ctx context.Context,
 	for _, node := range nodeList.Items {
 		// Get the node container runtime
 		runtimeVersion := node.Status.NodeInfo.ContainerRuntimeVersion
+
 		if runtimeVersion == "" {
 			return "", "", errors.Errorf("failed to get container runtime version")
 		}
 
 		// Get the container runtime name
 		runtimeName := strings.Split(runtimeVersion, ":")[0]
-		if runtimeName != "docker" && runtimeName != "containerd" {
+		klog.Infof("container runtime name: %s", runtimeName)
+		if runtimeName != "docker" && runtimeName != "containerd" && runtimeName != "cri-o" {
 			return "", "", errors.Errorf("unsupported container runtime %s", runtimeName)
 		}
 
@@ -568,6 +570,9 @@ func detectContainerRuntime(ctx context.Context,
 				runtimeSocket = "/var/run/containerd/containerd.sock"
 
 			}
+		} else if runtime == "cri-o" {
+			// If runtime is cri-o, we use the cri-o socket path
+			runtimeSocket = "/var/run/crio/crio.sock"
 		} else {
 			// The socket path is not provided in the annotation of OrchestCluster, so we use the default socket path
 			runtimeSocket = "/var/run/docker.sock"

--- a/utility-containers/image-builder-buildkit/Dockerfile
+++ b/utility-containers/image-builder-buildkit/Dockerfile
@@ -1,12 +1,17 @@
 FROM moby/buildkit:v0.10.4
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
-RUN buildkitd --version \
-    && buildctl --version \
+
+# Overwrite the apk repositories to use Alpine v3.16
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.16/main" > /etc/apk/repositories \
+    && echo "http://dl-cdn.alpinelinux.org/alpine/v3.16/community" >> /etc/apk/repositories \
     && apk update \
     && apk --no-cache upgrade openssh-client \
-    && apk add rsync \
+    && apk add rsync podman \
     && ssh-keygen -A \
     # To ssh from the jupyter server container while building to be
     # able to write to jupyter settings.
     && echo -e "root\nroot" | passwd root \
     && echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+
+RUN buildkitd --version \
+    && buildctl --version


### PR DESCRIPTION
…ross Orchest, enabling deployments on platforms like **Oracle Kubernetes Engine (OKE)**. Key changes include:

- Extended the `ContainerRuntime` class to support `cri-o`, including commands for inspecting and pulling images.
- Added image building support using `buildctl` and `podman` tailored to `cri-o`.
- Implemented a dedicated `DaemonSet` generator for deploying `buildkitd` in `cri-o` environments.
- Updated the controller to detect `cri-o` and configure socket paths and mounts appropriately.
- Enhanced API modules to include logging for active environment images and scheduler states.
- Modified the Dockerfile for the image builder to install `podman` and pin Alpine repositories for compatibility.

**Ticket**: [SOP-484](https://your-jira-instance/browse/SOP-484)

ADR detailing why those changes were made: 
https://github.com/dadosfera/dadosfera-ai-oss/tree/oracle-compatibility/adrs/crio

This enables users to deploy Orchest in Kubernetes clusters that use `cri-o`, broadening the range of supported environments.