### PR TITLE
**`BREAKING: fully migrate image references to dadosfera namespace`**

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -172,7 +172,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -226,7 +226,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -279,7 +279,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile_celery $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
   deploy_node_agent:
     needs: [calver_release, extract_environment]
@@ -325,7 +325,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -375,7 +375,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -426,7 +426,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -476,7 +476,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -525,7 +525,7 @@ jobs:
           cp .dockerignore $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -577,7 +577,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -629,7 +629,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-py/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -681,7 +681,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-r/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -733,7 +733,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-julia/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -785,7 +785,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-javascript/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -836,7 +836,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -886,7 +886,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -936,7 +936,7 @@ jobs:
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -440,43 +440,43 @@ jobs:
           docker system prune --volumes -a -f
           docker system df
 
-  # deploy_base_kernel_py:
-  #   needs: [calver_release, extract_environment]
-  #   runs-on: ubuntu-latest
-  #   environment: prd
-  #   if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  deploy_base_kernel_py:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-  #     - name: Build, Tag, and Push Image to Dockerhub
-  #       env:
-  #         REGISTRY: dadosfera
-  #         REPOSITORY: base-kernel-py
-  #         IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
-  #         BUILD_CTX: services/base-images
-  #       run: |
-  #         cp .dockerignore $BUILD_CTX
-  #         cp -r lib/ $BUILD_CTX
-  #         cp -r orchest-sdk/ $BUILD_CTX
-  #         docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-py/Dockerfile $BUILD_CTX
-  #         docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: base-kernel-py
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/base-images
+        run: |
+          cp .dockerignore $BUILD_CTX
+          cp -r lib/ $BUILD_CTX
+          cp -r orchest-sdk/ $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-py/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
-  #     - name: Cleanup Docker's Leftovers
-  #       if: always()
-  #       continue-on-error: true
-  #       run: |
-  #         docker system prune --volumes -a -f
-  #         docker system df
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
 
   deploy_base_kernel_r:
     needs: [calver_release, extract_environment]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,9 +54,9 @@ jobs:
         run: |
           if [ "${WORKFLOW_DISPATCH}" == "true" ] || [ "${BETA_BRANCH}" == "true" ]; then
             BRANCH_NAME=$(echo "${REF}" | sed 's|refs/heads/||')
-            echo "tag_name=v${NEXT_VERSION}.${BRANCH_NAME}" >> $GITHUB_OUTPUT
+            echo "tag_name=${NEXT_VERSION}.${BRANCH_NAME}" >> $GITHUB_OUTPUT
           else
-            echo "tag_name=v${NEXT_VERSION}" >> $GITHUB_OUTPUT
+            echo "tag_name=${NEXT_VERSION}" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -85,12 +89,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: orchest-webserver
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-webserver
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
@@ -101,6 +113,8 @@ jobs:
           cp package.json $BUILD_CTX/pnpm_files/
           cp tsconfig.json $BUILD_CTX/pnpm_files/
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -115,6 +129,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -128,12 +146,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: auth-server
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/auth-server/
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
@@ -144,6 +170,8 @@ jobs:
           cp package.json $BUILD_CTX/pnpm_files/
           cp tsconfig.json $BUILD_CTX/pnpm_files/
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -159,6 +187,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -172,18 +204,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: orchest-api
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-api
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           cp -r orchest-sdk/ $BUILD_CTX
           cp -r orchest-cli/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -198,6 +240,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -210,6 +256,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Build, Tag, and Push Image to Dockerhub
         env:
@@ -217,6 +269,8 @@ jobs:
           REPOSITORY: celery-worker
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-api
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
@@ -224,12 +278,18 @@ jobs:
           cp -r orchest-cli/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile_celery $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
   deploy_node_agent:
     needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -243,18 +303,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: node-agent
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/node-agent
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           cp -r orchest-sdk/ $BUILD_CTX
           cp -r orchest-cli/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -269,6 +339,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -282,15 +356,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: orchest-controller
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-controller
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -305,6 +389,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -317,6 +405,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Build, Tag, and Push Image to Dockerhub
         env:
@@ -324,18 +418,32 @@ jobs:
           REPOSITORY: jupyter-server
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/jupyter-server
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
 
   deploy_image_builder_buildkitd:
     needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -349,15 +457,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: image-builder-buildkit
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: utility-containers/image-builder-buildkit
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -372,6 +490,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -385,8 +507,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
           REGISTRY: dadosfera
           REPOSITORY: image-puller
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
@@ -394,7 +524,9 @@ jobs:
         run: |
           cp .dockerignore $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
         if: always()
@@ -408,6 +540,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -421,16 +557,26 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: jupyter-enterprise-gateway
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/jupyter-enterprise-gateway
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -445,6 +591,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -458,17 +608,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: base-kernel-py
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/base-images
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           cp -r orchest-sdk/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-py/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -483,6 +643,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -496,17 +660,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: base-kernel-r
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/base-images
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           cp -r orchest-sdk/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-r/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -521,6 +695,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -534,17 +712,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: base-kernel-julia
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/base-images
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           cp -r orchest-sdk/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-julia/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -559,6 +747,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -572,17 +764,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: base-kernel-javascript
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/base-images
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           cp -r orchest-sdk/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-javascript/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -597,6 +799,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -610,16 +816,26 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: session-sidecar
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/session-sidecar
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           cp -r lib/ $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -634,6 +850,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -647,15 +867,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: image-builder-buildx
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: utility-containers/image-builder-buildx
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -670,6 +900,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -683,15 +917,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Login to AWS ECR
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build, Tag, and Push Image to Dockerhub
         env:
           REGISTRY: dadosfera
           REPOSITORY: buildkit-daemon
           IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/buildkit-daemon
+          ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}
+          ECR_REGISTRY_ALIAS: u5k1d2l0
         run: |
           cp .dockerignore $BUILD_CTX
           docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
       - name: Cleanup Docker's Leftovers
@@ -700,4 +944,3 @@ jobs:
         run: |
           docker system prune --volumes -a -f
           docker system df
-        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -190,7 +190,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -243,7 +243,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -289,7 +289,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -342,7 +342,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -392,7 +392,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -443,7 +443,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -543,7 +543,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -594,7 +594,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -646,7 +646,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -698,7 +698,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -750,7 +750,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -802,7 +802,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -853,7 +853,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -903,7 +903,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      AWS_REGION: us-east-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,12 @@
 name: Deploy
 on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to deploy"
+        required: true
+        default: "beta"
+        type: string
   push:
     branches:
       - main
@@ -20,43 +27,49 @@ jobs:
           fi
         id: extract_environment
 
-  semantic_release:
+  calver_release:
     runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oracle-compatibility')) || github.event_name == 'workflow_dispatch' }}
     outputs:
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_published: ${{ steps.create_release.outputs.url != '' }}
+      new_release_version: ${{ steps.calver.outputs.next_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
-        id: semantic
+      - name: CalVer
+        id: calver
+        uses: energostack/calver-action@v1
         with:
-          semantic_version: 19
-          extra_plugins: |
-            @saithodev/semantic-release-backmerge@2
-            conventional-changelog-eslint@4.0.0
-          branches: |
-            [
-              'main',
-              {
-                name: 'alpha',
-                prerelease: true
-              },
-              {
-                name: 'beta',
-                prerelease: true
-              }
-            ]
+          prerelease: false
+
+      - name: Get Version
+        id: get_version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          BETA_BRANCH: ${{ github.ref == 'refs/heads/oracle-compatibility' }}
+          REF: ${{ github.ref }}
+          NEXT_VERSION: ${{ steps.calver.outputs.next_version }}
+        run: |
+          if [ ${WORKFLOW_DISPATCH} == "true" ] || [ ${BETA_BRANCH} == "true" ]; then
+            echo "tag_name=${NEXT_VERSION}.${REF}" >> $GITHUB_OUTPUT
+          else
+            echo "tag_name=${NEXT_VERSION}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        id: create_release
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag_name }}
+          generate_release_notes: true
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }} || ${{ github.ref == 'refs/heads/oracle-compatibility' }}
 
   deploy_webserver:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,7 +87,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: orchest-webserver
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-webserver
         run: |
           cp .dockerignore $BUILD_CTX
@@ -96,10 +109,10 @@ jobs:
           docker system df
 
   deploy_auth_server:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -117,7 +130,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: auth-server
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/auth-server/
         run: |
           cp .dockerignore $BUILD_CTX
@@ -140,10 +153,10 @@ jobs:
 
 
   deploy_api:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -161,7 +174,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: orchest-api
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-api
         run: |
           cp .dockerignore $BUILD_CTX
@@ -179,10 +192,10 @@ jobs:
           docker system df
 
   deploy_celery:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -200,7 +213,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: celery-worker
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-api
         run: |
           cp .dockerignore $BUILD_CTX
@@ -211,10 +224,10 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
   deploy_node_agent:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -232,7 +245,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: node-agent
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/node-agent
         run: |
           cp .dockerignore $BUILD_CTX
@@ -250,10 +263,10 @@ jobs:
           docker system df
 
   deploy_orchest_controller:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -271,7 +284,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: orchest-controller
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/orchest-controller
         run: |
           cp .dockerignore $BUILD_CTX
@@ -286,10 +299,10 @@ jobs:
           docker system df
 
   deploy_jupyter_server:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -307,7 +320,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: jupyter-server
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: services/jupyter-server
         run: |
           cp .dockerignore $BUILD_CTX
@@ -317,10 +330,10 @@ jobs:
 
 
   deploy_image_builder_buildkitd:
-    needs: [semantic_release, extract_environment]
+    needs: [calver_release, extract_environment]
     runs-on: ubuntu-latest
     environment: prd
-    if: needs.semantic_release.outputs.new_release_published == 'true'
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -338,7 +351,7 @@ jobs:
         env:
           REGISTRY: dadosfera
           REPOSITORY: image-builder-buildkit
-          IMAGE_TAG: v2023.04.2-${{ needs.semantic_release.outputs.new_release_version }}
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
           BUILD_CTX: utility-containers/image-builder-buildkit
         run: |
           cp .dockerignore $BUILD_CTX
@@ -351,3 +364,338 @@ jobs:
         run: |
           docker system prune --volumes -a -f
           docker system df
+
+  deploy_image_puller:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: image-puller
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: utility-containers/image-puller
+        run: |
+          cp .dockerignore $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  deploy_jupyter_enterprise_gateway:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: jupyter-enterprise-gateway
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/jupyter-enterprise-gateway
+        run: |
+          cp .dockerignore $BUILD_CTX
+          cp -r lib/ $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  # deploy_base_kernel_py:
+  #   needs: [calver_release, extract_environment]
+  #   runs-on: ubuntu-latest
+  #   environment: prd
+  #   if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+  #     - name: Build, Tag, and Push Image to Dockerhub
+  #       env:
+  #         REGISTRY: dadosfera
+  #         REPOSITORY: base-kernel-py
+  #         IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+  #         BUILD_CTX: services/base-images
+  #       run: |
+  #         cp .dockerignore $BUILD_CTX
+  #         cp -r lib/ $BUILD_CTX
+  #         cp -r orchest-sdk/ $BUILD_CTX
+  #         docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-py/Dockerfile $BUILD_CTX
+  #         docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+  #     - name: Cleanup Docker's Leftovers
+  #       if: always()
+  #       continue-on-error: true
+  #       run: |
+  #         docker system prune --volumes -a -f
+  #         docker system df
+
+  deploy_base_kernel_r:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: base-kernel-r
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/base-images
+        run: |
+          cp .dockerignore $BUILD_CTX
+          cp -r lib/ $BUILD_CTX
+          cp -r orchest-sdk/ $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-r/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  deploy_base_kernel_julia:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: base-kernel-julia
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/base-images
+        run: |
+          cp .dockerignore $BUILD_CTX
+          cp -r lib/ $BUILD_CTX
+          cp -r orchest-sdk/ $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-julia/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  deploy_base_kernel_javascript:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: base-kernel-javascript
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/base-images
+        run: |
+          cp .dockerignore $BUILD_CTX
+          cp -r lib/ $BUILD_CTX
+          cp -r orchest-sdk/ $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/base-kernel-javascript/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  deploy_session_sidecar:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: session-sidecar
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/session-sidecar
+        run: |
+          cp .dockerignore $BUILD_CTX
+          cp -r lib/ $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  deploy_image_builder_buildx:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: image-builder-buildx
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: utility-containers/image-builder-buildx
+        run: |
+          cp .dockerignore $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+
+  deploy_buildkit_daemon:
+    needs: [calver_release, extract_environment]
+    runs-on: ubuntu-latest
+    environment: prd
+    if: ${{ needs.calver_release.outputs.new_release_published == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build, Tag, and Push Image to Dockerhub
+        env:
+          REGISTRY: dadosfera
+          REPOSITORY: buildkit-daemon
+          IMAGE_TAG: ${{ needs.calver_release.outputs.new_release_version }}
+          BUILD_CTX: services/buildkit-daemon
+        run: |
+          cp .dockerignore $BUILD_CTX
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG --build-arg ORCHEST_VERSION=$IMAGE_TAG -f $BUILD_CTX/Dockerfile $BUILD_CTX
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Cleanup Docker's Leftovers
+        if: always()
+        continue-on-error: true
+        run: |
+          docker system prune --volumes -a -f
+          docker system df
+        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oracle-compatibility')) || github.event_name == 'workflow_dispatch' }}
     outputs:
       new_release_published: ${{ steps.create_release.outputs.url != '' }}
-      new_release_version: ${{ steps.calver.outputs.next_version }}
+      new_release_version: ${{ steps.get_version.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +41,7 @@ jobs:
         id: calver
         uses: energostack/calver-action@v1
         with:
+          date_format: '%Y.%m.%-d'
           prerelease: false
 
       - name: Get Version
@@ -51,10 +52,11 @@ jobs:
           REF: ${{ github.ref }}
           NEXT_VERSION: ${{ steps.calver.outputs.next_version }}
         run: |
-          if [ ${WORKFLOW_DISPATCH} == "true" ] || [ ${BETA_BRANCH} == "true" ]; then
-            echo "tag_name=${NEXT_VERSION}.${REF}" >> $GITHUB_OUTPUT
+          if [ "${WORKFLOW_DISPATCH}" == "true" ] || [ "${BETA_BRANCH}" == "true" ]; then
+            BRANCH_NAME=$(echo "${REF}" | sed 's|refs/heads/||')
+            echo "tag_name=v${NEXT_VERSION}.${BRANCH_NAME}" >> $GITHUB_OUTPUT
           else
-            echo "tag_name=${NEXT_VERSION}" >> $GITHUB_OUTPUT
+            echo "tag_name=v${NEXT_VERSION}" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Release

--- a/.github/workflows/test-calver.yml
+++ b/.github/workflows/test-calver.yml
@@ -1,0 +1,47 @@
+name: Test CalVer
+on:
+  push:
+    branches:
+      - main
+      - beta
+
+jobs:
+  calver_release:
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oracle-compatibility')) || github.event_name == 'workflow_dispatch' }}
+    outputs:
+      new_release_published: ${{ steps.create_release.outputs.url != '' }}
+      new_release_version: ${{ steps.get_version.outputs.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: CalVer
+        id: calver
+        uses: energostack/calver-action@v1
+        with:
+          date_format: '%Y.%m.%-d'
+          prerelease: false
+
+      - name: Get Version
+        id: get_version
+        env:
+          WORKFLOW_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          BETA_BRANCH: ${{ github.ref == 'refs/heads/oracle-compatibility' }}
+          REF: ${{ github.ref }}
+          NEXT_VERSION: ${{ steps.calver.outputs.next_version }}
+        run: |
+          if [ "${WORKFLOW_DISPATCH}" == "true" ] || [ "${BETA_BRANCH}" == "true" ]; then
+            BRANCH_NAME=$(echo "${REF}" | sed 's|refs/heads/||')
+            echo "tag_name=v${NEXT_VERSION}.${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          else
+            echo "tag_name=v${NEXT_VERSION}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        id: create_release
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag_name }}
+          generate_release_notes: true
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }} || ${{ github.ref == 'refs/heads/oracle-compatibility' }}

--- a/cypress/cypress/fixtures/custom/projects/data-passing/.orchest/environments/bb37767a-2e1a-4da3-9468-8c9ba1c91a6b/properties.json
+++ b/cypress/cypress/fixtures/custom/projects/data-passing/.orchest/environments/bb37767a-2e1a-4da3-9468-8c9ba1c91a6b/properties.json
@@ -3,5 +3,5 @@
   "language": "python",
   "uuid": "bb37767a-2e1a-4da3-9468-8c9ba1c91a6b",
   "name": "Python 3",
-  "base_image": "orchest/base-kernel-py"
+  "base_image": "dadosfera/base-kernel-py"
 }

--- a/cypress/cypress/fixtures/custom/projects/dump-env-params/.orchest/environments/4b3659e0-db0a-4ff0-9b60-fb53903dd218/properties.json
+++ b/cypress/cypress/fixtures/custom/projects/dump-env-params/.orchest/environments/4b3659e0-db0a-4ff0-9b60-fb53903dd218/properties.json
@@ -1,5 +1,5 @@
 {
-  "base_image": "orchest/base-kernel-py",
+  "base_image": "dadosfera/base-kernel-py",
   "gpu_support": false,
   "uuid": "4b3659e0-db0a-4ff0-9b60-fb53903dd218",
   "language": "python",

--- a/cypress/cypress/fixtures/custom/projects/services-connectivity/.orchest/environments/30cfd18d-c5ec-4651-8a9b-6e12c36fc3b5/properties.json
+++ b/cypress/cypress/fixtures/custom/projects/services-connectivity/.orchest/environments/30cfd18d-c5ec-4651-8a9b-6e12c36fc3b5/properties.json
@@ -3,5 +3,5 @@
   "language": "python",
   "uuid": "30cfd18d-c5ec-4651-8a9b-6e12c36fc3b5",
   "name": "Python 3",
-  "base_image": "orchest/base-kernel-py"
+  "base_image": "dadosfera/base-kernel-py"
 }

--- a/development/cluster.yaml
+++ b/development/cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-1
   namespace: orchest
   annotations:
-    controller.orchest.io/deploy-ingress: "false"
+    controller.orchest.io/deploy-ingress: "true"
 spec:
   singleNode: true
   orchest:
@@ -45,6 +45,8 @@ spec:
       env:
         - name: ORCHEST_LOG_LEVEL
           value: DEBUG
+        - name: NODE_ENV
+          value: development
     env:
       - name: CLOUD_ENVIRONMENT
         value: "local"

--- a/development/controller.yaml
+++ b/development/controller.yaml
@@ -1687,7 +1687,7 @@ spec:
       serviceAccountName: orchest-controller
       containers:
       - name: orchest-controller
-        image: "docker.io/orchest/orchest-controller:v2023.04.2"
+        image: "docker.io/dadosfera/orchest-controller:v2023.04.2"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/lib/python/orchest-internals/_orchest/internals/config.py
+++ b/lib/python/orchest-internals/_orchest/internals/config.py
@@ -38,7 +38,7 @@ GPU_ENABLED_INSTANCE = os.environ.get("ORCHEST_GPU_ENABLED_INSTANCE") == "True"
 # CPU SHARES.
 USER_CONTAINERS_CPU_SHARES = "1m"
 SINGLE_NODE = os.environ.get("SINGLE_NODE", True)
-USER_CONTAINERS_MEMORY_SHARES = None if SINGLE_NODE == "TRUE" else "100Mi"
+USER_CONTAINERS_MEMORY_SHARES = None if SINGLE_NODE == "TRUE" else os.environ.get("USER_CONTAINER_MEMORY_SHARES", "65Mi")
 
 REGISTRY = "docker-registry"
 # NOTE: The DNS resolver will not treat this as an FQDN perse (depending
@@ -130,7 +130,7 @@ DEFAULT_SETUP_SCRIPT = """#!/bin/bash
 DEFAULT_ENVIRONMENTS = [
     {
         "name": "Python 3",
-        "base_image": "orchest/base-kernel-py",
+        "base_image": "dadosfera/base-kernel-py",
         "language": "python",
         "setup_script": DEFAULT_SETUP_SCRIPT,
         "gpu_support": False,
@@ -139,4 +139,4 @@ DEFAULT_ENVIRONMENTS = [
 
 SIDECAR_PORT = 1111
 
-ORCHEST_UPDATE_INFO_URL = "https://api.github.com/repos/orchest/orchest/releases/latest"
+ORCHEST_UPDATE_INFO_URL = "https://api.github.com/repos/dadosfera/dadosfera-ai-oss/releases/latest"

--- a/scripts/build_container.sh
+++ b/scripts/build_container.sh
@@ -251,7 +251,7 @@ do
 
         build_ctx=$DIR/../services/jupyter-server
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/jupyter-server:$BUILD_TAG" \
+            -t "dadosfera/jupyter-server:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/jupyter-server/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -265,7 +265,7 @@ do
 
         build_ctx=$DIR/../services/jupyter-enterprise-gateway
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/jupyter-enterprise-gateway:$BUILD_TAG" \
+            -t "dadosfera/jupyter-enterprise-gateway:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/jupyter-enterprise-gateway/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -277,7 +277,7 @@ do
 
         build_ctx=$DIR/../services/orchest-api
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/celery-worker:$BUILD_TAG" \
+            -t "dadosfera/celery-worker:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/orchest-api/Dockerfile_celery \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -291,7 +291,7 @@ do
 
         build_ctx=$DIR/../services/base-images
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/base-kernel-py:$BUILD_TAG" \
+            -t "dadosfera/base-kernel-py:$BUILD_TAG" \
             -f $DIR/../services/base-images/base-kernel-py/Dockerfile \
             --no-cache=$NO_CACHE \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -303,7 +303,7 @@ do
 
         build_ctx=$DIR/../services/base-images
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/base-kernel-julia:$BUILD_TAG" \
+            -t "dadosfera/base-kernel-julia:$BUILD_TAG" \
             -f $DIR/../services/base-images/base-kernel-julia/Dockerfile \
             --no-cache=$NO_CACHE \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -315,7 +315,7 @@ do
 
         build_ctx=$DIR/../services/base-images
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/base-kernel-javascript:$BUILD_TAG" \
+            -t "dadosfera/base-kernel-javascript:$BUILD_TAG" \
             -f $DIR/../services/base-images/base-kernel-javascript/Dockerfile \
             --no-cache=$NO_CACHE \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -327,7 +327,7 @@ do
 
         build_ctx=$DIR/../services/base-images
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/base-kernel-r:$BUILD_TAG" \
+            -t "dadosfera/base-kernel-r:$BUILD_TAG" \
             -f $DIR/../services/base-images/base-kernel-r/Dockerfile \
             --no-cache=$NO_CACHE \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -339,7 +339,7 @@ do
 
         build_ctx=$DIR/../services/orchest-api
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/orchest-api:$BUILD_TAG" \
+            -t "dadosfera/orchest-api:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/orchest-api/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -350,7 +350,7 @@ do
 
         build_ctx=$DIR/../services/node-agent
         build=(docker build --progress=plain \
-            -t "orchest/node-agent:$BUILD_TAG" \
+            -t "dadosfera/node-agent:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/node-agent/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -361,7 +361,7 @@ do
 
         build_ctx=$DIR/../services/orchest-webserver
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/orchest-webserver:$BUILD_TAG" \
+            -t "dadosfera/orchest-webserver:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/orchest-webserver/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -372,7 +372,7 @@ do
 
         build_ctx=$DIR/../services/auth-server
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/auth-server:$BUILD_TAG" \
+            -t "dadosfera/auth-server:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/auth-server/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -383,7 +383,7 @@ do
 
         build_ctx=$DIR/../services/orchest-controller
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/orchest-controller:$BUILD_TAG" \
+            -t "dadosfera/orchest-controller:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/orchest-controller/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -404,7 +404,7 @@ do
     if [ $IMG == "session-sidecar" ]; then
         build_ctx=$DIR/../services/session-sidecar
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/session-sidecar:$BUILD_TAG" \
+            -t "dadosfera/session-sidecar:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/session-sidecar/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -415,7 +415,7 @@ do
     if [ $IMG == "image-puller" ]; then
         build_ctx=$DIR/../utility-containers/image-puller
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/image-puller:$BUILD_TAG" \
+            -t "dadosfera/image-puller:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../utility-containers/image-puller/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -425,7 +425,7 @@ do
     if [ $IMG == "image-builder-buildx" ]; then
         build_ctx=$DIR/../utility-containers/image-builder-buildx
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/image-builder-buildx:$BUILD_TAG" \
+            -t "dadosfera/image-builder-buildx:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../utility-containers/image-builder-buildx/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -435,7 +435,7 @@ do
     if [ $IMG == "image-builder-buildkit" ]; then
         build_ctx=$DIR/../utility-containers/image-builder-buildkit
         build=(docker build --platform linux/amd64 --progress=plain \
-            -t "orchest/image-builder-buildkit:$BUILD_TAG" \
+            -t "dadosfera/image-builder-buildkit:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../utility-containers/image-builder-buildkit/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"
@@ -446,7 +446,7 @@ do
 
         build_ctx=$DIR/../services/buildkit-daemon
         build=(docker build --progress=plain \
-            -t "orchest/buildkit-daemon:$BUILD_TAG" \
+            -t "dadosfera/buildkit-daemon:$BUILD_TAG" \
             --no-cache=$NO_CACHE \
             -f $DIR/../services/buildkit-daemon/Dockerfile \
             --build-arg ORCHEST_VERSION="$ORCHEST_VERSION"

--- a/services/base-images/base-kernel-py/Dockerfile
+++ b/services/base-images/base-kernel-py/Dockerfile
@@ -2,10 +2,6 @@
 FROM jupyter/base-notebook:2022-03-09
 LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-ARG AWS_DEFAULT_REGION
-
 USER root
 
 # defailt-libmysqlclient-dev : Orchest dependency
@@ -22,7 +18,6 @@ RUN passwd -d $NB_USER \
     && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" | tee --append /etc/sudoers.d/$NB_USER \
     # All files in this directory should be mode 0440.
     && chmod 0440 /etc/sudoers.d/$NB_USER
-
 
 # Get Enterprise Gateway kernel files.
 WORKDIR /usr/local/bin
@@ -85,13 +80,6 @@ ENV HOME=/home/$NB_USER
 ENV BASH_ENV=/home/jovyan/.orchestrc
 
 
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-ARG AWS_DEFAULT_REGION
-
-RUN mamba run pip install awscli
-RUN aws codeartifact login --tool pip --domain dadosfera --domain-owner 611330257153 --region us-east-1 --repository dadosfera-pip && \
-    mamba run pip install brain==2.0.0a11
 # Orchest related environment variable that can be set to specify the
 # conda environment to use to start Jupyter kernels.
 ENV CONDA_ENV="base"

--- a/services/base-images/dadosfera-base-kernel-py-agent/Dockerfile
+++ b/services/base-images/dadosfera-base-kernel-py-agent/Dockerfile
@@ -16,7 +16,7 @@ USER root
 #     apt-get clean && \
 #     && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends curl openssh-server git default-libmysqlclient-dev libkrb5-dev libxcb1 \
+    && apt-get install -yq --no-install-recommends cmake curl openssh-server git default-libmysqlclient-dev libkrb5-dev libxcb1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN passwd -d $NB_USER \
@@ -38,16 +38,20 @@ RUN wget https://github.com/jupyter-server/enterprise_gateway/releases/download/
     && chown -R jovyan:users /usr/local/bin/kernel-launchers
 
 # Install Enterprise Gateway requirements.
-RUN mamba install --quiet --yes \
+
+RUN mamba create -y -n py311 python=3.11 future
+RUN mamba install -n py311 --quiet --yes \
     cffi \
     ipykernel \
     ipython \
     'jupyter_client<7' \
     future \
-    pycryptodomex && \
+    pycryptodome \
+    ipython_genutils && \
     mamba clean --all -f -y && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
+
 
 # Get all Orchest requirements in place.
 COPY ./runnable-shared/runner/requirements* /orchest/services/base-images/runnable-shared/runner/
@@ -64,19 +68,24 @@ WORKDIR /orchest/services/base-images/runnable-shared/runner
 # Install user requirements to be able to use Orchest. Install them in
 # the `base` conda environment as it is default environment.
 # NOTE: Use `pip` so we can install from local sources.
-RUN pip install -r requirements-user.txt --no-cache
+RUN pip install uv
+RUN uv pip install -r requirements-user.txt --no-cache --system
 
 # Install Orchest dependencies in our own environment so they are
 # completely isolated from user dependencies. Use a venv instead
 # of conda environment because it is much smaller.
 RUN python -m venv /home/$NB_USER/venv \
     && source /home/$NB_USER/venv/bin/activate \
-    && pip install -r requirements.txt --no-cache \
+    && uv pip install -r requirements.txt --no-cache --system \
     && deactivate
 
 # Empty configuration file for kernel initialization
-RUN touch /home/jovyan/.orchestrc && \
+RUN touch ~/.orchestrc && \
     echo "export PS1='\${ENVIRONMENT_SHELL_NAME:+(\$ENVIRONMENT_SHELL_NAME)}\[\033[01;32m\]\u\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> ~/.bashrc
+
+RUN echo "export JUPYTER_PATH=/opt/conda/envs/py311/share/jupyter" >> ~/.orchestrc
+RUN echo "export PATH='/opt/conda/envs/py311/bin/:$PATH'" >> ~/.orchestrc
+RUN echo "export CONDA_ENV=py311" >> ~/.orchestrc
 
 # Copy application files as late as possible to avoid cache busting.
 COPY ./runnable-shared/runner* /orchest/services/base-images/runnable-shared/runner

--- a/services/base-images/runnable-shared/runner/requirements-user.txt
+++ b/services/base-images/runnable-shared/runner/requirements-user.txt
@@ -3,4 +3,5 @@
 # Pin version to avoid breaking coupling with jupyterlab_widgets,
 # see https://github.com/jupyter-widgets/ipywidgets/issues/3577
 ipywidgets>=7.0,<8
+pyarrow==7.0.0
 -e ../../../../orchest-sdk/python/

--- a/services/base-images/runnable-shared/runner/requirements.in
+++ b/services/base-images/runnable-shared/runner/requirements.in
@@ -3,4 +3,5 @@ ipykernel>=6.0.0
 ipython
 nbconvert
 nbformat
+ipython_genutils
 -e file:../../../../lib/python/orchest-internals

--- a/services/node-agent/Dockerfile
+++ b/services/node-agent/Dockerfile
@@ -14,7 +14,7 @@ ENV CONTAINERD_DOWNLOAD_URL="https://github.com/containerd/containerd/releases/d
 # injection did not fix the issue, like in kubernetes for docker for
 # desktop.
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends buildah podman \
+    && apt-get install -yq --no-install-recommends buildah podman fuse-overlayfs \
     && buildah version \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/services/node-agent/Dockerfile
+++ b/services/node-agent/Dockerfile
@@ -14,7 +14,7 @@ ENV CONTAINERD_DOWNLOAD_URL="https://github.com/containerd/containerd/releases/d
 # injection did not fix the issue, like in kubernetes for docker for
 # desktop.
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends buildah \
+    && apt-get install -yq --no-install-recommends buildah podman \
     && buildah version \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/services/node-agent/app/container_runtime.py
+++ b/services/node-agent/app/container_runtime.py
@@ -225,8 +225,7 @@ class ContainerRuntime(object):
             result, _, _ = await self.execute_cmd(cmd=cmd)
         elif self.container_runtime in [RuntimeType.Crio]:
             cmd = (
-                f"crictl -r unix://{self.container_runtime_socket} "
-                f"pull {image_name} --skip-verify "
+                f"podman pull {image_name} --tls-verify=false"
             )
             result, _, _ = await self.execute_cmd(cmd=cmd)
 

--- a/services/orchest-api/app/app/apis/namespace_ctl.py
+++ b/services/orchest-api/app/app/apis/namespace_ctl.py
@@ -112,9 +112,7 @@ class ListPods(Resource):
 class OrchestImagesToPrePull(Resource):
 
     def _get_jupyter_image_name(self):
-        if CONFIG_CLASS.JUPYTER_SERVER_IMAGE == "docker.io/orchest/jupyter-server":
-            return f"docker.io/orchest/jupyter-server:{CONFIG_CLASS.ORCHEST_VERSION}"
-        return f"{CONFIG_CLASS.JUPYTER_SERVER_IMAGE}:{CONFIG_CLASS.ORCHEST_DADOSFERA_VERSION}"
+        return f"{CONFIG_CLASS.JUPYTER_SERVER_IMAGE}:{CONFIG_CLASS.ORCHEST_VERSION}"
 
     @api.doc("orchest_images_to_pre_pull")
     def get(self):
@@ -123,9 +121,9 @@ class OrchestImagesToPrePull(Resource):
             CONFIG_CLASS.IMAGE_BUILDER_IMAGE,
             _config.ARGO_EXECUTOR_IMAGE,
             _config.CONTAINER_RUNTIME_IMAGE,
-            f"docker.io/orchest/base-kernel-py:{CONFIG_CLASS.ORCHEST_VERSION}",
-            f"docker.io/orchest/jupyter-enterprise-gateway:{CONFIG_CLASS.ORCHEST_VERSION}",  # noqa
-            f"docker.io/orchest/session-sidecar:{CONFIG_CLASS.ORCHEST_VERSION}"
+            f"docker.io/dadosfera/base-kernel-py:{CONFIG_CLASS.ORCHEST_VERSION}",
+            f"docker.io/dadosfera/jupyter-enterprise-gateway:{CONFIG_CLASS.ORCHEST_VERSION}",  # noqa
+            f"docker.io/dadosfera/session-sidecar:{CONFIG_CLASS.ORCHEST_VERSION}"
         ]
 
         pre_pull_orchest_images.append(self._get_jupyter_image_name())

--- a/services/orchest-api/app/app/apis/namespace_environment_images.py
+++ b/services/orchest-api/app/app/apis/namespace_environment_images.py
@@ -104,7 +104,7 @@ def _get_formatted_active_environment_imgs(
         stored_in_registry=stored_in_registry, in_node=in_node, not_in_node=not_in_node
     )
 
-    logger.info(f"Active Env Images: {active_env_images}")
+    logger.debug(f"Active Env Images: {active_env_images}")
     active_env_images_names = []
     registry_ip = utils.get_registry_ip()
     for img in active_env_images:
@@ -116,7 +116,7 @@ def _get_formatted_active_environment_imgs(
             + str(img.tag)
         )
         active_env_images_names.append(f"{registry_ip}/{image}")
-    logger.info(f"Active Env Images With Name: \n{active_env_images_names}")
+    logger.debug(f"Active Env Images With Name: \n{active_env_images_names}")
 
     return active_env_images_names
 
@@ -158,7 +158,7 @@ class ActiveEnvironmentImagesToPush(Resource):
             in_node=request.args.get("in_node"),
         )
 
-        logger.info(f"/to-push - Active Images: {active_env_images}")
+        logger.debug(f"/to-push - Active Images: {active_env_images}")
         # This to avoid image pushes running concurrently with a
         # registry GC, we avoid the race condition by having the
         # PROCESS_IMAGE_DELETION task status be updated and then having
@@ -171,7 +171,7 @@ class ActiveEnvironmentImagesToPush(Resource):
         scheduler_is_deleting_images = scheduler.is_running(
             scheduler.SchedulerJobType.PROCESS_IMAGES_FOR_DELETION
         )
-        logger.info(f"Scheduler is running: {scheduler_is_deleting_images}")
+        logger.debug(f"Scheduler is running: {scheduler_is_deleting_images}")
         if scheduler_is_deleting_images:
             active_env_images = []
 
@@ -192,7 +192,7 @@ class ProjectEnvironmentDanglingImages(Resource):
         or job which are pending or running."""
 
         return {"message": "Successfully removed dangling images."}, 200
-
+    
 
 class DeleteProjectEnvironmentImages(TwoPhaseFunction):
     def _transaction(self, project_uuid: str):

--- a/services/orchest-api/app/app/core/environment_image_builds.py
+++ b/services/orchest-api/app/app/core/environment_image_builds.py
@@ -304,8 +304,8 @@ def prepare_build_context(task_uuid, project_uuid, environment_uuid, project_pat
         environment_properties = json.load(json_file)
         base_image: str = environment_properties["base_image"]
         # Workaround for common.tsx not using the orchest version.
-        if "orchest/" in base_image:
-            if ":" not in base_image.split("orchest/")[1]:
+        if "dadosfera/" in base_image:
+            if ":" not in base_image.split("dadosfera/")[1]:
                 base_image = f"{base_image}:{CONFIG_CLASS.ORCHEST_VERSION}"
 
     # Use the task_uuid to avoid clashing with user stuff.

--- a/services/orchest-api/app/app/core/environment_image_builds.py
+++ b/services/orchest-api/app/app/core/environment_image_builds.py
@@ -92,6 +92,7 @@ def write_environment_dockerfile(
     else:
         full_basename = f"docker.io/{base_image}"
 
+
     statements.append(f"FROM {full_basename}")
     statements.append(f"LABEL _orchest_project_uuid={project_uuid}")
     statements.append(f"LABEL _orchest_environment_uuid={env_uuid}")
@@ -304,6 +305,10 @@ def prepare_build_context(task_uuid, project_uuid, environment_uuid, project_pat
         environment_properties = json.load(json_file)
         base_image: str = environment_properties["base_image"]
         # Workaround for common.tsx not using the orchest version.
+
+        if "orchest/" in base_image:
+            base_image = base_image.replace("orchest/", "dadosfera/")
+
         if "dadosfera/" in base_image:
             if ":" not in base_image.split("dadosfera/")[1]:
                 base_image = f"{base_image}:{CONFIG_CLASS.ORCHEST_VERSION}"

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -523,7 +523,3 @@ def build_image(
             return "FAILURE"
 
         return "SUCCESS"
-
-if __name__ == "__main__":
-
-    _get_image_builder_manifest("teste","orchest/base_kernel","latest","a","a")

--- a/services/orchest-api/app/app/core/image_utils.py
+++ b/services/orchest-api/app/app/core/image_utils.py
@@ -86,15 +86,40 @@ _RUNTIME_TO_IMAGE_BUILDER_VOLUMES = {
     ],
 }
 
+
 _IMAGE_BUILDER_VOLUME_MOUNTS = _RUNTIME_TO_IMAGE_BUILDER_VOLUME_MOUNTS[
     _config.CONTAINER_RUNTIME
 ] + _utils.get_temp_aws_volume_mounts()
+
 _IMAGE_BUILDER_VOLUMES = (
     _RUNTIME_TO_IMAGE_BUILDER_VOLUMES[_config.CONTAINER_RUNTIME] +
     _utils.get_temp_aws_volumes()
 )
 
 
+if CONFIG_CLASS.DOCKERHUB_SECRET_NAME:
+    _IMAGE_BUILDER_VOLUME_MOUNTS = _IMAGE_BUILDER_VOLUME_MOUNTS + [
+        {
+            "name": "dockerhub-secret",
+            "mountPath": "/root/.docker",
+            "readOnly": True,
+        }
+    ]
+
+    _IMAGE_BUILDER_VOLUMES = _IMAGE_BUILDER_VOLUMES + [
+        {
+            "name": "dockerhub-secret",
+            "secret": {
+                "secretName": CONFIG_CLASS.DOCKERHUB_SECRET_NAME,
+                "items": [
+                    {
+                        "key": ".dockerconfigjson",
+                        "path": "config.json",
+                    }
+                ],
+            },
+        }
+    ]
 
 def _get_image_builder_manifest(
     workflow_name,

--- a/services/orchest-api/app/app/core/jupyter_image_builds.py
+++ b/services/orchest-api/app/app/core/jupyter_image_builds.py
@@ -179,7 +179,7 @@ def prepare_build_context(task_uuid):
         # Create empty shell script if no setup_script exists.
         os.system(f'touch "{snapshot_setup_script_path}"')
 
-    base_image = f"orchest/jupyter-server:{CONFIG_CLASS.ORCHEST_VERSION}"
+    base_image = f"dadosfera/jupyter-server:{CONFIG_CLASS.ORCHEST_VERSION}"
 
     # Copy the settings into the context to make them available during
     # build. It's done in this "simple" manner to be compatible with all

--- a/services/orchest-api/app/app/core/pod_scheduling.py
+++ b/services/orchest-api/app/app/core/pod_scheduling.py
@@ -124,13 +124,12 @@ def _is_jupyter_image_in_registry(tag: Union[int, str]) -> bool:
 
 
 def _get_node_affinity_to_random_node(node_names: List[str]) -> Dict[str, Any]:
-    # Need to set a specific node at the application level:
-    # https://github.com/kubernetes/kubernetes/issues/78238.
     return {
         "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                    {
+            "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                    "weight": 100,
+                    "preference": {
                         "matchFields": [
                             {
                                 "key": "metadata.name",
@@ -139,8 +138,8 @@ def _get_node_affinity_to_random_node(node_names: List[str]) -> Dict[str, Any]:
                             }
                         ]
                     }
-                ],
-            }
+                }
+            ]
         }
     }
 

--- a/services/orchest-api/app/app/core/sessions/_manifests.py
+++ b/services/orchest-api/app/app/core/sessions/_manifests.py
@@ -253,7 +253,7 @@ def _get_session_sidecar_deployment_manifest(
                         {
                             "name": metadata["name"],
                             "image": (
-                                "orchest/session-sidecar:"
+                                "dadosfera/session-sidecar:"
                                 + CONFIG_CLASS.ORCHEST_VERSION
                             ),
                             # NOTE: It would be a good idea to increase
@@ -807,7 +807,7 @@ def _get_jupyter_enterprise_gateway_deployment_service_manifest(
                         {
                             "name": metadata["name"],
                             "image": (
-                                "orchest/jupyter-enterprise-gateway:"
+                                "dadosfera/jupyter-enterprise-gateway:"
                                 + CONFIG_CLASS.ORCHEST_VERSION
                             ),
                             "resources": {

--- a/services/orchest-api/app/app/core/tasks.py
+++ b/services/orchest-api/app/app/core/tasks.py
@@ -539,7 +539,7 @@ def _get_git_import_pod_manifest(
             "containers": [
                 {
                     "name": "git-import",
-                    "image": f"orchest/celery-worker:{_config.ORCHEST_VERSION}",
+                    "image": f"dadosfera/celery-worker:{_config.ORCHEST_VERSION}",
                     "command": ["/bin/sh", "-c"],
                     "args": [args],
                     "env": [],

--- a/services/orchest-api/app/app/utils.py
+++ b/services/orchest-api/app/app/utils.py
@@ -331,9 +331,7 @@ def get_jupyter_server_image_to_use() -> str:
         registry_ip = get_registry_ip()
         return f"{registry_ip}/{_config.JUPYTER_IMAGE_NAME}:{custom_image.tag}"
     else:
-        if CONFIG_CLASS.JUPYTER_SERVER_IMAGE == "docker.io/orchest/jupyter-server":
-            return f"docker.io/orchest/jupyter-server:{CONFIG_CLASS.ORCHEST_VERSION}"
-        return f"{CONFIG_CLASS.JUPYTER_SERVER_IMAGE}:{CONFIG_CLASS.ORCHEST_DADOSFERA_VERSION}"
+        return f"{CONFIG_CLASS.JUPYTER_SERVER_IMAGE}:{CONFIG_CLASS.ORCHEST_VERSION}"
 
 def get_registry_ip() -> str:
     return k8s_core_api.read_namespaced_service(

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -32,8 +32,7 @@ class Config:
     # Whether Orchest is running on single-node. This in turn determines
     # how pipeline runs are executed; in 1 pod or 1 pod per step.
     SINGLE_NODE = os.environ.get("SINGLE_NODE") == "TRUE"
-    ORCHEST_VERSION = os.environ["ORCHEST_VERSION"].split("-")[0]
-    ORCHEST_DADOSFERA_VERSION = os.environ["ORCHEST_VERSION"]
+    ORCHEST_VERSION = os.environ["ORCHEST_VERSION"]
     # must be uppercase
     SQLALCHEMY_DATABASE_URI = "postgresql://postgres@orchest-database/orchest_api"
 
@@ -65,15 +64,15 @@ class Config:
     _RUNTIME_TO_IMAGE_BUILDER = {
         "docker": os.environ.get(
             "DOCKER_IMAGE_BUILDER_IMAGE",
-            f"docker.io/orchest/image-builder-buildx:{ORCHEST_VERSION}",
+            f"docker.io/dadosfera/image-builder-buildx:{ORCHEST_VERSION}",
         ),
         "containerd": os.environ.get(
             "CONTAINERD_IMAGE_BUILDER_IMAGE",
-            f"docker.io/orchest/image-builder-buildkit:{ORCHEST_VERSION}",
+            f"docker.io/dadosfera/image-builder-buildkit:{ORCHEST_VERSION}",
         ),
         "cri-o": os.environ.get(
             "CRIO_IMAGE_BUILDER_IMAGE",
-            f"docker.io/orchest/image-builder-buildkit:{ORCHEST_VERSION}",
+            f"docker.io/dadosfera/image-builder-buildkit:{ORCHEST_VERSION}",
         ),
     }
     IMAGE_BUILDER_IMAGE = _RUNTIME_TO_IMAGE_BUILDER[_config.CONTAINER_RUNTIME]
@@ -81,7 +80,7 @@ class Config:
     BUILD_IMAGE_LOG_FLAG = "_ORCHEST_RESERVED_LOG_FLAG_"
     BUILD_IMAGE_ERROR_FLAG = "_ORCHEST_RESERVED_ERROR_FLAG_"
     JUPYTER_SERVER_IMAGE = os.environ.get(
-        "JUPYTER_SERVER_IMAGE", "docker.io/orchest/jupyter-server"
+        "JUPYTER_SERVER_IMAGE", "docker.io/dadosfera/jupyter-server"
     )
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.

--- a/services/orchest-api/app/config.py
+++ b/services/orchest-api/app/config.py
@@ -82,6 +82,7 @@ class Config:
     JUPYTER_SERVER_IMAGE = os.environ.get(
         "JUPYTER_SERVER_IMAGE", "docker.io/dadosfera/jupyter-server"
     )
+    DOCKERHUB_SECRET_NAME = os.environ.get("DOCKERHUB_SECRET_NAME")
     # ---- Celery configurations ----
     # NOTE: the configurations have to be lowercase.
     # NOTE: Flask will not configure lowercase variables. Therefore the

--- a/services/orchest-controller/pkg/apis/orchest/v1alpha1/types.go
+++ b/services/orchest-controller/pkg/apis/orchest/v1alpha1/types.go
@@ -254,6 +254,8 @@ type OrchestClusterSpec struct {
 	WorkerNodeSelector map[string]string `json:"workerNodeSelector,omitempty"`
 
 	CorePriorityClassName string `json:"corePriorityClassName,omitempty"`
+
+	DockerhubSecretName string `json:"dockerhubSecretName,omitempty"`
 }
 
 type Condition struct {

--- a/services/orchest-controller/pkg/apis/orchest/v1alpha1/zz_generated.deepcopy.go
+++ b/services/orchest-controller/pkg/apis/orchest/v1alpha1/zz_generated.deepcopy.go
@@ -219,6 +219,9 @@ func (in *OrchestClusterSpec) DeepCopyInto(out *OrchestClusterSpec) {
 		}
 	}
 	out.CorePriorityClassName = in.CorePriorityClassName
+	if in.DockerhubSecretName != "" {
+		out.DockerhubSecretName = in.DockerhubSecretName
+	}
 	return
 }
 

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_controller.go
@@ -79,10 +79,10 @@ func NewDefaultControllerConfig() ControllerConfig {
 		PostgresDefaultImage:          "postgres:13.1",
 		RabbitmqDefaultImage:          "rabbitmq:3",
 		OrchestDefaultVersion:         version.Version,
-		CeleryWorkerImageName:         "orchest/celery-worker",
-		OrchestApiImageName:           "orchest/orchest-api",
-		OrchestWebserverImageName:     "orchest/orchest-webserver",
-		AuthServerImageName:           "orchest/auth-server",
+		CeleryWorkerImageName:         "dadosfera/celery-worker",
+		OrchestApiImageName:           "dadosfera/orchest-api",
+		OrchestWebserverImageName:     "dadosfera/orchest-webserver",
+		AuthServerImageName:           "dadosfera/auth-server",
 		UserdirDefaultVolumeSize:      "50Gi",
 		OrchestStateDefaultVolumeSize: "5Gi",
 		BuilddirDefaultVolumeSize:     "25Gi",
@@ -94,7 +94,7 @@ func NewDefaultControllerConfig() ControllerConfig {
 		OrchestApiDefaultEnvVars: map[string]string{
 			"ORCHEST_GPU_ENABLED_INSTANCE": "FALSE",
 			"FLASK_ENV":                    "production",
-			"JUPYTER_SERVER_IMAGE":         "docker.io/orchest/jupyter-server",
+			"JUPYTER_SERVER_IMAGE":         "docker.io/dadosfera/jupyter-server",
 		},
 		OrchestWebserverDefaultEnvVars: map[string]string{
 			"ORCHEST_GPU_ENABLED_INSTANCE": "FALSE",

--- a/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
+++ b/services/orchest-controller/pkg/controller/orchestcluster/cluster_utils.go
@@ -270,6 +270,13 @@ func getOrchestComponent(name, hash string,
 			}})
 		}
 
+		if orchest.Spec.DockerhubSecretName != "" {
+			template.Env = utils.MergeEnvVars(template.Env, []corev1.EnvVar{{
+				Name:  "DOCKERHUB_SECRET_NAME",
+				Value: orchest.Spec.DockerhubSecretName,
+			}})
+		}
+
 	case controller.Rabbitmq:
 		template.NodeSelector = orchest.Spec.ControlNodeSelector
 		template.StateVolumeName = orchestStateVolumeName
@@ -288,6 +295,13 @@ func getOrchestComponent(name, hash string,
 				Value: string(jsonStr),
 			}})
 		}
+
+		if orchest.Spec.DockerhubSecretName != "" {
+			template.Env = utils.MergeEnvVars(template.Env, []corev1.EnvVar{{
+				Name:  "DOCKERHUB_SECRET_NAME",
+				Value: orchest.Spec.DockerhubSecretName,
+			}})
+		}
 	case controller.AuthServer:
 		template.NodeSelector = orchest.Spec.ControlNodeSelector
 	case controller.OrchestWebserver:
@@ -295,6 +309,12 @@ func getOrchestComponent(name, hash string,
 		template.StateVolumeName = controller.UserDirName
 	case controller.NodeAgent:
 		template.NodeSelector = orchest.Spec.WorkerNodeSelector
+		if orchest.Spec.DockerhubSecretName != "" {
+			template.Env = utils.MergeEnvVars(template.Env, []corev1.EnvVar{{
+				Name:  "DOCKERHUB_SECRET_NAME",
+				Value: orchest.Spec.DockerhubSecretName,
+			}})
+		}
 	case controller.BuildKitDaemon:
 		template.NodeSelector = orchest.Spec.WorkerNodeSelector
 	default:

--- a/services/orchest-controller/pkg/controller/orchestcomponent/node_agent.go
+++ b/services/orchest-controller/pkg/controller/orchestcomponent/node_agent.go
@@ -73,10 +73,8 @@ func getNodeAgentDaemonset(registryIP string, metadata metav1.ObjectMeta,
 	*appsv1.DaemonSet, error) {
 
 	image := component.Spec.Template.Image
-	extraEnvVars := []corev1.EnvVar{}
 
 
-	envMap := utils.GetMapFromEnvVar(component.Spec.Template.Env, extraEnvVars)
 	socketPath := utils.GetKeyFromEnvVar(component.Spec.Template.Env, "CONTAINER_RUNTIME_SOCKET")
 	// Apparently needed for old/existing clusters?
 	socketPath = strings.Replace(socketPath, "unix://", "", -1)
@@ -198,14 +196,6 @@ func getNodeAgentDaemonset(registryIP string, metadata metav1.ObjectMeta,
 				},
 			},
 		)
-
-	
-		devMod := isDevelopmentEnabled(envMap)
-		if devMod {
-			devVolumes, devVolumeMounts := getDevVolumes(controller.NodeAgent, true, false, true)
-			template.Spec.Volumes = append(template.Spec.Volumes, devVolumes...)
-			template.Spec.Containers[0].VolumeMounts = append(template.Spec.Containers[0].VolumeMounts, devVolumeMounts...)
-		}
 
 		// And the secret needs to be mounted into the container
 		template.Spec.Containers[0].VolumeMounts = append(template.Spec.Containers[0].VolumeMounts,

--- a/services/orchest-controller/pkg/utils/k8s_utils.go
+++ b/services/orchest-controller/pkg/utils/k8s_utils.go
@@ -262,10 +262,10 @@ func GetFullImageName(registry, imageName, tag string) string {
 		tag = "latest"
 	}
 	if registry != "" {
-		return fmt.Sprintf("%s/orchest/%s:%s", registry, imageName, tag)
+		return fmt.Sprintf("%s/dadosfera/%s:%s", registry, imageName, tag)
 	}
 
-	return fmt.Sprintf("orchest/%s:%s", imageName, tag)
+	return fmt.Sprintf("dadosfera/%s:%s", imageName, tag)
 }
 
 func GetPatchData(oldObj, newObj interface{}) ([]byte, error) {

--- a/services/orchest-webserver/client/src/environments-view/common.tsx
+++ b/services/orchest-webserver/client/src/environments-view/common.tsx
@@ -130,28 +130,28 @@ export const DEFAULT_BASE_IMAGES: (CustomImage & {
   unavailable?: boolean;
 })[] = [
   {
-    base_image: "orchest/base-kernel-py",
+    base_image: "dadosfera/base-kernel-py",
     img_src: "/image/python_logo.svg",
     language: "python",
     gpu_support: false,
     label: "Python",
   },
   {
-    base_image: "orchest/base-kernel-r",
+    base_image: "dadosfera/base-kernel-r",
     img_src: "/image/r_logo.svg",
     language: "r",
     gpu_support: false,
     label: "R",
   },
   {
-    base_image: "orchest/base-kernel-julia",
+    base_image: "dadosfera/base-kernel-julia",
     img_src: "/image/julia_logo.svg",
     language: "julia",
     gpu_support: false,
     label: "Julia",
   },
   {
-    base_image: "orchest/base-kernel-javascript",
+    base_image: "dadosfera/base-kernel-javascript",
     img_src: "/image/javascript_logo.svg",
     language: "javascript",
     gpu_support: false,

--- a/services/orchest-webserver/client/src/pipeline-settings-view/ServiceTemplatesDialog/content.tsx
+++ b/services/orchest-webserver/client/src/pipeline-settings-view/ServiceTemplatesDialog/content.tsx
@@ -37,7 +37,7 @@ export const templates: ServiceTemplates = {
         "/data": "/data",
         "/project-dir": "/project-dir",
       },
-      args: "-c 'umask 002 && streamlit run /project-dir/src/Home.py'",
+      args: "-c 'umask 002 && mkdir -p /project-dir/src && touch /project-dir/src/Home.py && streamlit run /project-dir/src/Home.py'",
       command: "bash",
       env_variables: {
         STREAMLIT_SERVER_BASE_URL_PATH: "$BASE_PATH_PREFIX_8501",

--- a/utility-containers/image-puller/Dockerfile
+++ b/utility-containers/image-puller/Dockerfile
@@ -17,6 +17,9 @@ ENV DOCKER_DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/
 RUN curl -L $DOCKER_DOWNLOAD_URL | tar -xz -C /tmp/download \
     && mv /tmp/download/docker/docker /bin/
 
+RUN curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.1/crictl-v1.24.1-linux-amd64.tar.gz --output crictl-v1.24.1-linux-amd64.tar.gz \
+    && tar -xzf crictl-v1.24.1-linux-amd64.tar.gz -C /usr/local/bin
+
 
 RUN rm -rf /tmp/download \
     && apk del curl \
@@ -29,6 +32,7 @@ LABEL maintainer="Orchest B.V. https://www.orchest.io"
 
 COPY --from=base /bin/ctr /bin/ctr
 COPY --from=base /bin/docker /bin/docker
+COPY --from=base /usr/local/bin/crictl /usr/local/bin/crictl
 
 RUN apt-get update && apt-get install -y buildah && buildah version && \
     apt-get clean

--- a/utility-containers/image-puller/pull_image.sh
+++ b/utility-containers/image-puller/pull_image.sh
@@ -28,7 +28,13 @@ elif [ "$CONTAINER_RUNTIME" = docker ]; then
         ln -s /var/run/runtime.sock /var/run/docker.sock
         buildah push --disable-compression "${IMAGE_TO_PULL}" "docker-daemon:${IMAGE_TO_PULL}"
     fi
-
+elif [ "$CONTAINER_RUNTIME" = cri-o ]; then
+    image_exist=$(crictl -r unix:///var/run/runtime.sock images -q "${IMAGE_TO_PULL}")
+    if [ -n "${image_exist}" ]; then
+        echo "Image ${IMAGE_TO_PULL} exists, skip pulling."
+        exit 0
+    fi
+    crictl -r unix:///var/run/runtime.sock pull "${IMAGE_TO_PULL}" --skip-verify
 else
     echo "Container runtime is not supported"
     exit 1


### PR DESCRIPTION
This commit performs a comprehensive renaming across the codebase, transitioning all Docker image references from the legacy `orchest/`
 namespace to the new `dadosfera/` convention. This change aligns with our open-source strategy and simplifies image versioning and CI/CD management.

**Key changes:**
- All references to Docker images under `orchest/` have been updated to `dadosfera/` across Kubernetes manifests, controller configs, backend logic, and CI workflows.
- Introduced new deploy jobs for additional `dadosfera` images like `buildkit-daemon`, `session-sidecar`, and various `base-kernel-*` containers.
- Switched from semantic release to `calver-action` in GitHub workflows for versioning strategy.
- Updated `pull_image.sh` and Dockerfiles to support CRI-O runtime and enhanced container pulling flexibility.
- Refactored internal logic in Python and Go code to assume the `dadosfera/` prefix as the standard.

These changes are **breaking** as they assume all environments (local, CI, production) now use the `dadosfera` namespace and associated version tags exclusively.

**Github:** #41